### PR TITLE
chore: Update Node.js version from 20 to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -106,11 +106,6 @@ runs:
           exit 1
         fi
 
-    - name: Ensure Node.js available
-      uses: actions/setup-node@v4
-      with:
-        node-version: "24"
-
     - name: Check repository write access
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
`dist/main.js` has `??` in it, and node 20 does not support it.
This problem breaks custom runners