### PR TITLE
fix: update actions/setup-node to use a specific commit hash

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -107,7 +107,9 @@ runs:
         fi
 
     - name: Ensure Node.js available
-      uses: actions/setup-node@v4
+      # Pin to a commit hash because some repositories require it:
+      # https://github.com/openai/codex-action/issues/43
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: "20"
 


### PR DESCRIPTION
Fixes https://github.com/openai/codex-action/issues/43.