### PR TITLE
fix: CI was not terminating when dist.js was not updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,9 @@ jobs:
 
       - name: Ensure dist matches bundled output
         run: |
-          if [[ -n "$(git status --porcelain dist)" ]]; then
+          status_output="$(git status --short -- dist)"
+          if [[ -n "$status_output" ]]; then
             echo '::error::Detected modified files in dist/ after running pnpm run build. Please rebuild locally and commit the updated bundles.'
-            git --no-pager diff dist
+            echo "$status_output"
             exit 1
           fi


### PR DESCRIPTION
I noticed that this action appeared to "hang" when it failed. Codex's hypothesis:

> The “hang” is the runner spewing an enormous diff. `dist/main.js` includes the entire sourcemap as a base64 data URI, so any real change rewrites megabytes of single-line text. When the `Ensure dist matches bundled output` step hits the failure branch, `git --no-pager diff dist` tries to stream that whole blob to the Actions log. GitHub throttles large log output, so the step sits there for a long time while it slowly uploads the diff, which looks like a hang even though the job is just printing. The quickest fix is to stop dumping the full diff—e.g. swap in `git --no-pager diff --stat dist` or `git status --short dist` so the log stays tiny and the step fails immediately.

Let's try its proposed fix.