### PR TITLE
fix: unset codex-version default; should pick up 0.60.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,8 +34,7 @@ inputs:
   codex-version:
     description: "Version of `@openai/codex` to install."
     required: false
-    # Temporary fix to prevent picking up 0.59.0.
-    default: "0.58.0"
+    default: ""
   codex-args:
     description: "Additional args to pass through to `codex exec`. If this value starts with `[`, it will be parsed as a JSON array; otherwise, it will be parsed as a shell-like string."
     required: false


### PR DESCRIPTION
Undo temporary fix from https://github.com/openai/codex-action/pull/56 where we pinned the default version of the CLI to `0.58.0`. Now the action will go back to picking up the latest version.

I tested this with:

```yaml
name: Run Codex Exec
on:
  workflow_dispatch:
    inputs:
      prompt:
        description: Prompt to send to Codex
        default: "What OS is this and what is cwd?"
        required: false

jobs:
  codex:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v5

      - name: Start Codex proxy
        uses: openai/codex-action@4e66262d88002f5b291881bbd4a4eff2824ab421
        with:
          openai-api-key: ${{ secrets.OPENAI_API_KEY }}

      - name: Run Codex
        uses: openai/codex-action@4e66262d88002f5b291881bbd4a4eff2824ab421
        id: codex
        with:
          prompt: ${{ github.event.inputs.prompt }}
          sandbox: "read-only"
          output-file: "/tmp/result.txt"

      - name: Capture Codex result
        run: |
          echo "New Codex said: ${{ steps.codex.outputs.final-message }}"

      - name: Try output file
        run: cat /tmp/result.txt
```

For the `Run Codex` step, it ran with version `v0.60.1` of the CLI and used the `gpt-5.1-codex` model.