### PR TITLE
Properly diff the PR against `master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ jobs:
             This is PR #${{ github.event.pull_request.number }} for ${{ github.repository }}.
 
             Review ONLY the changes introduced by the PR, so consider:
-               git log --oneline ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
+               git log --oneline ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
 
             Suggest any improvements, potential bugs, or issues.
             Be concise and specific in your feedback.


### PR DESCRIPTION
Bug: When master moves forward, the new commits on master are also included in `base...head`, which makes it look like parts of the PR are “reverting” them.

Fix: When reviewing the PR, don't use the `base...head` notation (which includes all commits reachable from base or head BUT not from both). Instead, use `base..head` (commits reachable from head which are not reachable from base).