### PR TITLE
Add token usage to the action outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ See [Protecting your `OPENAI_API_KEY`](./docs/security.md#protecting-your-openai
 | Name            | Description                             |
 | --------------- | --------------------------------------- |
 | `final-message` | Final message returned by `codex exec`. |
+| `tokens-used`   | The number of tokens used.              |
 
 As we saw in the example above, we took the `final-message` output of the `run_codex` step and made it an output of the `codex` job in the workflow:
 

--- a/action.yml
+++ b/action.yml
@@ -101,6 +101,9 @@ outputs:
   final-message:
     description: "Raw output emitted by `codex exec`."
     value: ${{ steps.run_codex.outputs['final-message'] }}
+  tokens-used:
+    description: "Number of tokens used as reported by `codex exec`."
+    value: ${{ steps.run_codex.outputs['tokens-used'] }}
 runs:
   using: "composite"
   steps:

--- a/src/runCodexExec.ts
+++ b/src/runCodexExec.ts
@@ -1,5 +1,6 @@
 import { spawn } from "child_process";
 import { chmod, mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import fs from "fs";
 import path from "path";
 import os from "os";
 import { setOutput } from "@actions/core";
@@ -80,6 +81,8 @@ export async function runCodexExec({
   } else {
     outputFile = await createTempOutputFile({ runAsUser });
   }
+
+  let logFile = await createTempLogFile({ runAsUser });
 
   const resolvedOutputSchema = await resolveOutputSchema(
     outputSchema,
@@ -163,13 +166,19 @@ export async function runCodexExec({
       .join(" ")}`
   );
   try {
+    const outStream = fs.createWriteStream(logFile, { flags: "a" });
     await new Promise((resolve, reject) => {
       const child = spawn(program, command, {
         env,
-        stdio: ["pipe", "inherit", "inherit"],
+        stdio: ["pipe", "pipe", "inherit"],
       });
       child.stdin.write(input);
       child.stdin.end();
+
+      child.stdout.on("data", (chunk) => {
+        process.stdout.write(chunk);
+        outStream.write(chunk);
+      });
 
       child.on("error", reject);
 
@@ -181,6 +190,7 @@ export async function runCodexExec({
 
         try {
           await finalizeExecution(outputFile, runAsUser);
+          await setTokenUsage(logFile, runAsUser);
           resolve(undefined);
         } catch (err) {
           reject(err);
@@ -212,6 +222,30 @@ async function finalizeExecution(
     setOutput("final-message", lastMessage);
   } finally {
     await cleanupTempOutput(outputFile, runAsUser);
+  }
+}
+
+async function setTokenUsage(
+  logFile: string,
+  runAsUser: string | null
+): Promise<void> {
+  try {
+    let outputLog: string;
+    if (runAsUser == null) {
+      outputLog = await readFile(logFile, "utf8");
+    } else {
+      outputLog = await checkOutput([
+        "sudo",
+        "-u",
+        runAsUser,
+        "cat",
+        logFile,
+      ]);
+    }
+    let tokensUsed = outputLog.match(/tokens used\s+([\d.]+)/);
+    setOutput("tokens-used", tokensUsed);
+  } finally {
+    await cleanupTempOutput({file: logFile, type: "temp"}, runAsUser);
   }
 }
 
@@ -264,6 +298,15 @@ async function cleanupTempOutput(
       break;
     }
   }
+}
+
+async function createTempLogFile({
+  runAsUser,
+}: {
+  runAsUser: string | null;
+}): Promise<string> {
+  const dir = await createTempDir("codex-exec-", runAsUser);
+  return path.join(dir, "output.log");
 }
 
 async function resolveOutputSchema(


### PR DESCRIPTION
Hi there, first of all thanks for making this GitHub action wrapper for Codex available 🙏

For an integration at work, I was looking into options for retrieving the total number of tokens used by the codex execution. After coming up empty while looking into the command line options of the `codex` CLI, I noticed the output log already captures the total amount of tokens used.

Therefore, I figured the easiest way to achieve what I want is to capture the output to a logfile besides sending it to `stdout` and then parse the tokens used when the run has finished.

I'm filing this PR mostly to see if there is interest in this approach, I haven't tested my changes yet. Happy to contribute further if this is going into a desirable direction at all. Apologies if this is a waste of your time 😬

