### PR TITLE
Fail fast on empty openai-api-key to prevent misleading server-info ENOENT

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -155,6 +155,16 @@ runs:
         server_info_file="${{ steps.resolve_home.outputs.codex-home }}/${{ github.run_id }}.json"
         echo "server_info_file=$server_info_file" >> "$GITHUB_OUTPUT"
 
+    - name: Validate OpenAI API key input
+      if: ${{ inputs.prompt != '' || inputs['prompt-file'] != '' }}
+      shell: bash
+      run: |
+        openai_api_key="${{ inputs['openai-api-key'] }}"
+        if [ -z "${openai_api_key//[[:space:]]/}" ]; then
+          echo "openai-api-key input is empty. Set OPENAI_API_KEY secret and pass it to this action." >&2
+          exit 1
+        fi
+
     - name: Check Responses API proxy status
       id: start_proxy
       if: ${{ inputs['openai-api-key'] != '' }}
@@ -218,7 +228,7 @@ runs:
     # This step has an output named `port`.
     - name: Read server info
       id: read_server_info
-      if: ${{ inputs['openai-api-key'] != '' || inputs.prompt != '' || inputs['prompt-file'] != '' }}
+      if: ${{ inputs['openai-api-key'] != '' }}
       shell: bash
       run: node "${{ github.action_path }}/dist/main.js" read-server-info "${{ steps.derive_server_info.outputs.server_info_file }}"
 


### PR DESCRIPTION
## Summary

  Fixes issue #70 by adding explicit preflight validation for openai-api-key and preventing downstream server-info
  reads when proxy startup cannot occur.

  ## Root cause

  Read server info could run when prompt/prompt-file was set even if openai-api-key was empty. In that case, proxy
  startup was skipped, no <run_id>.json was created, and the action later failed with a misleading ENOENT error.

  ## Fix

  - Added a preflight step in action.yml (for prompt executions) that trims openai-api-key and fails fast when empty:
      - openai-api-key input is empty. Set OPENAI_API_KEY secret and pass it to this action.
  - Updated Read server info step condition to run only when openai-api-key is non-empty.

  ## Before / After

  - Before: missing/blank key could fail later with Failed to read server info ... ENOENT.
  - After: missing/blank key fails immediately with a clear actionable message; downstream read-server-info does not
    run on invalid startup paths.
  - Valid key path: unchanged.

  ## Scope

  Minimal, focused change in action.yml only.