### PR TITLE
docs: update CHANGELOG for v1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # codex-action Changelog
 
+## [v1.8](https://github.com/openai/codex-action/tree/v1.8) (2026-04-29)
+
+- [#91](https://github.com/openai/codex-action/pull/91) tighten what bots are allowed
+
 ## [v1.7](https://github.com/openai/codex-action/tree/v1.7) (2026-04-24)
 
 - [#89](https://github.com/openai/codex-action/pull/89) restrict bot permission bypass


### PR DESCRIPTION
## Why

Prepare the repository for the `v1.8` release. Following the existing release flow, the changelog needs a `v1.8` entry before the specific version tag is cut and the floating `v1` tag is moved.

## What Changed

- Added a `v1.8` section to `CHANGELOG.md` dated `2026-04-29`.
- Documented #91 as the release contents: tightening the allowed bot behavior.

## Verification

- Confirmed this is a changelog-only change with `sl diff`.
- No tests were run because no runtime code changed.