### PR TITLE
Fix `codex-home` input for `safety-strategy: unprivileged-user`

### DIFF
--- a/src/runCodexExec.ts
+++ b/src/runCodexExec.ts
@@ -114,7 +114,7 @@ export async function runCodexExec({
       throw new Error("could not find 'codex' in PATH");
     }
 
-    command.push("sudo", "-u", codexUser, "--");
+    command.push("sudo", "-E", "-u", codexUser, "--");
   }
 
   command.push(


### PR DESCRIPTION
`sudo` resets the environment by default.

When the `codex-home` input is set, `runCodexExec` adds `CODEX_HOME` to the environment passed to `spawn()`. For `unprivileged-user`, however, the spawned process is `sudo`, which then runs `codex exec` as the target user. Without preserving the environment, `CODEX_HOME` is not propagated to the Codex process, so the CLI may read configuration from the target user's default Codex home instead.

This change passes `-E` (`--preserve-env`) to `sudo` so the unprivileged Codex process receives the environment prepared by the action.

Fixes #99