### PR TITLE
docs: clarify PR-controlled project instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ jobs:
         with:
           # Explicitly check out the PR's merge commit.
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          persist-credentials: false
 
       - name: Pre-fetch base and head refs for the PR
         env:

--- a/docs/security.md
+++ b/docs/security.md
@@ -14,7 +14,8 @@ There is a lot of valuable context that can be used to fuel your invocation of C
 
 - **Pull requests**: the title of a pull request is often clear, but it is fairly easy to hide information in a pull request body using an HTML comment (`<!-- -->`) that is readily available to the model but effectively invisible to the user.
 - **Commit messages**: a pull request can be composed of many commits. The messages for individual commits often go unnoticed, but could read by Codex.
-- **Screenshots** screenshots and other media have been known to be used as vehicles for prompt injection.
+- **Repository instruction files**: when Codex operates on pull request-controlled content, files such as `AGENTS.md`, `AGENTS.override.md`, or configured fallback project docs from that content should be considered part of the untrusted input surface.
+- **Screenshots**: screenshots and other media have been known to be used as vehicles for prompt injection.
 
 ## Avoid shell injection in workflow steps
 


### PR DESCRIPTION
## Summary

- clarify that PR-controlled project instruction files such as `AGENTS.md` and `AGENTS.override.md` are untrusted input
- add safer pull request review guidance to `docs/security.md`
- harden the README example with `persist-credentials: false` and a note about instruction files present in the active workspace

## Why

The existing security guidance already covers prompt injection and risky workflow configurations. This update makes the project-instruction-file case explicit so users can reason about pull request review workflows more clearly.

## Validation

- `git diff --check`
