### PR TITLE
docs: update CHANGELOG for v1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # codex-action Changelog
 
+## [v1.9](https://github.com/openai/codex-action/tree/v1.9) (2026-06-22)
+
+- [#85](https://github.com/openai/codex-action/pull/85) update the internal `setup-node` pin to `v6.3.0`
+
 ## [v1.8](https://github.com/openai/codex-action/tree/v1.8) (2026-04-29)
 
 - [#91](https://github.com/openai/codex-action/pull/91) tighten what bots are allowed


### PR DESCRIPTION
## Why

Prepare the repository for the `v1.9` release. Following the existing release flow, the changelog needs a `v1.9` entry before the specific version tag is cut and the floating `v1` tag is moved.

This release captures #85, which updates the internal `actions/setup-node` pin to `v6.3.0` to address the Node 20 deprecation warning from the action dependency itself.

## What Changed

- Added a `v1.9` section to `CHANGELOG.md` dated `2026-06-22`.
- Documented #85 as the release contents: updating the internal `setup-node` pin to `v6.3.0`.

## Verification

- Confirmed this is a changelog-only change with `sl diff`.
- No tests were run because no runtime code changed.