### PR TITLE
Fix Responses API proxy hang on ARC runners with k8s

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -217,7 +217,8 @@ runs:
 
         (
           printenv PROXY_API_KEY | env -u PROXY_API_KEY "${args[@]}"
-        ) &
+        ) </dev/null >>"${RUNNER_TEMP:-/tmp}/codex-responses-api-proxy.log" 2>&1 &
+        disown
 
     - name: Wait for Responses API proxy
       if: ${{ inputs['openai-api-key'] != '' && steps.start_proxy.outputs.server_info_file_exists == 'false' }}


### PR DESCRIPTION
Fixes #108.
On Actions Runner Controller (ARC) in kubernetes container mode, backgrounding codex-responses-api-proxy without redirecting stdout/stderr holds the parent step's exec stream open. This causes the hook to hang until the websocket heartbeat times out.

This commit detaches stdio while preserving proxy output in a log file, and uses disown to resolve the hang. GitHub-hosted runners are unaffected.