### PR TITLE
docs: update CHANGELOG for v1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # codex-action Changelog
 
+## [v1.10](https://github.com/openai/codex-action/tree/v1.10) (2026-07-02)
+
+- [#113](https://github.com/openai/codex-action/pull/113) add Codex permission profile support
+
 ## [v1.9](https://github.com/openai/codex-action/tree/v1.9) (2026-06-22)
 
 - [#85](https://github.com/openai/codex-action/pull/85) update the internal `setup-node` pin to `v6.3.0`


### PR DESCRIPTION
## Why

The [`v1.10`](https://github.com/openai/codex-action/tree/v1.10) tag now publishes the permission-profile support added in [#113](https://github.com/openai/codex-action/pull/113), but the changelog on `main` still stops at `v1.9`. Record the release so users browsing the repository can discover the new tag and its contents.

## What Changed

- Added a `v1.10` section to `CHANGELOG.md` dated `2026-07-02`.
- Documented #113 as the release contents: adding Codex permission-profile support.

## Verification

- Confirmed this is a changelog-only change with `sl diff`.
- No tests were run because no runtime code changed.