### PR TITLE
docs: update CHANGELOG for v1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # codex-action Changelog
 
+## [v1.11](https://github.com/openai/codex-action/tree/v1.11) (2026-07-04)
+
+- [#116](https://github.com/openai/codex-action/pull/116) keep the permission profile helper backward compatible
+
 ## [v1.10](https://github.com/openai/codex-action/tree/v1.10) (2026-07-02)
 
 - [#113](https://github.com/openai/codex-action/pull/113) add Codex permission profile support


### PR DESCRIPTION
## Why

The `v1.11` release now points to the merge commit for #116, but the changelog only documents releases through `v1.10`.

## What changed

- Add a dated `v1.11` changelog entry.
- Link the release tag and summarize the backward-compatibility fix from #116.

## Testing

Documentation-only change.
