### PR TITLE
Recommend fetching immutable commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,19 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          # Explicitly check out the PR's merge commit.
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          # Pin the merge commit captured by the pull_request event.
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - name: Pre-fetch base and head refs for the PR
         env:
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Pass GitHub expressions through env and quote shell expansions.
           git fetch --no-tags origin \
-            "$PR_BASE_REF" \
-            "+refs/pull/$PR_NUMBER/head"
+            "$PR_BASE_SHA" \
+            "$PR_HEAD_SHA"
 
       # If you want Codex to build and run code, install any dependencies that
       # need to be downloaded before the "Run Codex" step. The recommended

--- a/docs/security.md
+++ b/docs/security.md
@@ -17,6 +17,12 @@ There is a lot of valuable context that can be used to fuel your invocation of C
 - **Repository instruction files**: when Codex operates on pull request-controlled content, files such as `AGENTS.md`, `AGENTS.override.md`, or configured fallback project docs from that content should be considered part of the untrusted input surface.
 - **Screenshots**: screenshots and other media have been known to be used as vehicles for prompt injection.
 
+## Pin pull request revisions to the triggering event
+
+Pull request refs such as `refs/pull/<number>/merge`, `refs/pull/<number>/head`, and branch names can change after a maintainer approves or triggers a workflow. Check out and fetch immutable commit SHAs from the triggering event instead. For `pull_request` workflows, `github.sha` is the event's merge commit; `github.event.pull_request.head.sha` and `github.event.pull_request.base.sha` identify the corresponding head and base commits.
+
+Checking the triggering actor's repository permissions does not establish trust in the checked-out code. In privileged workflows such as `pull_request_target` or `issue_comment`, do not execute fork-controlled code or load fork-controlled files as trusted instructions. Pinning a SHA prevents the revision from changing; it does not make untrusted code safe.
+
 ## Limit command permissions
 
 Use `permission-profile` to select the narrowest filesystem and network policy that still lets Codex

--- a/docs/security.md
+++ b/docs/security.md
@@ -51,9 +51,9 @@ Instead, pass those values through `env:` and quote the shell variables that con
 ```yaml
 - name: Safe shell usage
   env:
-    PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+    PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
   run: |
-    git fetch origin "$PR_BASE_REF"
+    git fetch origin "$PR_BASE_SHA"
 ```
 
 <!-- TODO ## Protecting secrets -->


### PR DESCRIPTION
Update the README and security documentation to recommend checking out and fetching immutable commit SHAs from the triggering pull request event. 

This prevents mutable PR or branch references from changing between workflow approval and execution.