### PR TITLE
Harden CI workflow with zizmor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,17 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@02f6c237bd2518259fed6c71566509edfb3f2b74 # v4
@@ -19,7 +24,7 @@ jobs:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: "pnpm"

--- a/action.yml
+++ b/action.yml
@@ -154,13 +154,15 @@ runs:
       shell: bash
       env:
         CODEX_VERSION: ${{ inputs['codex-version'] }}
-      run: npm install -g "@openai/codex@${CODEX_VERSION}"
+      run: | # zizmor: ignore[adhoc-packages]
+        npm install -g "@openai/codex@${CODEX_VERSION}"
 
     - name: Install Codex Responses API proxy
       shell: bash
       env:
         CODEX_VERSION: ${{ inputs['codex-version'] }}
-      run: npm install -g "@openai/codex-responses-api-proxy@${CODEX_VERSION}"
+      run: | # zizmor: ignore[adhoc-packages]
+        npm install -g "@openai/codex-responses-api-proxy@${CODEX_VERSION}"
 
     - name: Resolve Codex home
       id: resolve_home


### PR DESCRIPTION
Unresolved: dangerous-triggers in cla.yml; needs workflow redesign.
Unresolved: archived-uses in cla.yml; needs CLA migration.
~~Unresolved: adhoc-packages in action.yml; runtime installs need redesign.~~

Note: the CLA findings are known; I've previously triaged them as safe but we should still migrate away from `pull_request_target` long term. I've also explicitly ignored the `adhoc-packages` findings because they're sort of intrinsic to how the action works right now. Longer term we could consider a setup-uv approach where everything gets fully hash-pinned.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>