### PR TITLE
fix: validate Responses proxy liveness before reuse

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -193,14 +193,9 @@ runs:
       if: ${{ inputs['openai-api-key'] != '' }}
       shell: bash
       env:
+        ACTION_PATH: ${{ github.action_path }}
         SERVER_INFO_FILE: ${{ steps.derive_server_info.outputs.server_info_file }}
-      run: |
-        if [ -s "$SERVER_INFO_FILE" ]; then
-          echo "Responses API proxy already appears to be running (found $SERVER_INFO_FILE)."
-          echo "server_info_file_exists=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "server_info_file_exists=false" >> "$GITHUB_OUTPUT"
-        fi
+      run: node "$ACTION_PATH/scripts/checkResponsesProxyStatus.mjs" "$SERVER_INFO_FILE"
 
     # This is its own step to minimize the runtime logic that has access to the
     # API key. Note we use `env -u PROXY_API_KEY` to ensure extra copies of the

--- a/scripts/checkResponsesProxyStatus.mjs
+++ b/scripts/checkResponsesProxyStatus.mjs
@@ -1,0 +1,125 @@
+import { appendFileSync, readFileSync, rmSync, statSync } from "node:fs";
+import net from "node:net";
+import { spawnSync } from "node:child_process";
+
+const serverInfoFile = process.argv[2];
+if (!serverInfoFile) {
+  throw new Error("server info file path is required");
+}
+
+const outputFile = process.env.GITHUB_OUTPUT;
+if (!outputFile) {
+  throw new Error("GITHUB_OUTPUT is required");
+}
+
+function setExists(exists) {
+  appendFileSync(
+    outputFile,
+    `server_info_file_exists=${exists ? "true" : "false"}\n`,
+    "utf8"
+  );
+}
+
+function readServerInfo() {
+  try {
+    if (statSync(serverInfoFile).size === 0) {
+      return null;
+    }
+    const parsed = JSON.parse(readFileSync(serverInfoFile, "utf8"));
+    if (
+      !Number.isInteger(parsed.pid) ||
+      parsed.pid <= 0 ||
+      !Number.isInteger(parsed.port) ||
+      parsed.port <= 0 ||
+      parsed.port > 65535
+    ) {
+      return null;
+    }
+    return { pid: parsed.pid, port: parsed.port };
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return null;
+    }
+    return null;
+  }
+}
+
+function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists but this user cannot signal it.
+    return error?.code === "EPERM";
+  }
+}
+
+function portAcceptsConnections(port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    let settled = false;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(value);
+    };
+    socket.setTimeout(500, () => finish(false));
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+  });
+}
+
+function removeStaleServerInfo() {
+  try {
+    rmSync(serverInfoFile, { force: true });
+    return;
+  } catch (error) {
+    if (process.platform === "win32") {
+      throw error;
+    }
+  }
+
+  const result = spawnSync(
+    "sudo",
+    ["-n", "rm", "-f", "--", serverInfoFile],
+    { stdio: "inherit" }
+  );
+  if (result.error || result.status !== 0) {
+    throw new Error(
+      `stale Responses API proxy server info could not be removed: ${serverInfoFile}`
+    );
+  }
+}
+
+const serverInfo = readServerInfo();
+if (serverInfo == null) {
+  // Missing and empty files need no cleanup. Malformed non-empty files do.
+  try {
+    if (statSync(serverInfoFile).size > 0) {
+      console.log(`Removing invalid Responses API proxy server info: ${serverInfoFile}`);
+      removeStaleServerInfo();
+    }
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+  setExists(false);
+  process.exit(0);
+}
+
+const live =
+  processExists(serverInfo.pid) &&
+  (await portAcceptsConnections(serverInfo.port));
+
+if (live) {
+  console.log(
+    `Responses API proxy is running (pid ${serverInfo.pid}, port ${serverInfo.port}).`
+  );
+  setExists(true);
+} else {
+  console.log(
+    `Removing stale Responses API proxy server info (pid ${serverInfo.pid}, port ${serverInfo.port}).`
+  );
+  removeStaleServerInfo();
+  setExists(false);
+}

--- a/test/checkResponsesProxyStatus.test.mjs
+++ b/test/checkResponsesProxyStatus.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(
+  new URL("../scripts/checkResponsesProxyStatus.mjs", import.meta.url)
+);
+
+function runStatus(serverInfoFile) {
+  const outputFile = `${serverInfoFile}.output`;
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath, serverInfoFile], {
+      env: { ...process.env, GITHUB_OUTPUT: outputFile },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.on("error", reject);
+    child.on("close", (status) => {
+      let output = "";
+      try {
+        output = readFileSync(outputFile, "utf8");
+      } catch {}
+      resolve({ status, stdout, stderr, output });
+    });
+  });
+}
+
+test("reports a missing server-info file as not running", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "codex-proxy-status-"));
+  const serverInfo = path.join(dir, "missing.json");
+  try {
+    const result = await runStatus(serverInfo);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.output, "server_info_file_exists=false\n");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("removes malformed server info and reports not running", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "codex-proxy-status-"));
+  const serverInfo = path.join(dir, "server.json");
+  writeFileSync(serverInfo, "not json", "utf8");
+  try {
+    const result = await runStatus(serverInfo);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.output, "server_info_file_exists=false\n");
+    assert.throws(() => readFileSync(serverInfo, "utf8"), /ENOENT/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("removes dead proxy metadata and reports not running", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "codex-proxy-status-"));
+  const serverInfo = path.join(dir, "server.json");
+  writeFileSync(
+    serverInfo,
+    JSON.stringify({ pid: 2147483647, port: 65535 }),
+    "utf8"
+  );
+  try {
+    const result = await runStatus(serverInfo);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.output, "server_info_file_exists=false\n");
+    assert.throws(() => readFileSync(serverInfo, "utf8"), /ENOENT/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("reuses metadata only when both pid and loopback port are live", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "codex-proxy-status-"));
+  const serverInfo = path.join(dir, "server.json");
+  const server = net.createServer(() => {});
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  writeFileSync(
+    serverInfo,
+    JSON.stringify({ pid: process.pid, port: address.port }),
+    "utf8"
+  );
+
+  try {
+    const result = await runStatus(serverInfo);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.output, "server_info_file_exists=true\n");
+    assert.match(result.stdout, /Responses API proxy is running/);
+    assert.equal(
+      JSON.parse(readFileSync(serverInfo, "utf8")).port,
+      address.port
+    );
+  } finally {
+    server.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Verify that an existing Responses API proxy is actually alive before reusing its server-info file.

Fixes #133.

## Problem

`codex-action` currently treats a non-empty server-info JSON file as proof that the proxy is still running:

```bash
if [ -s "$SERVER_INFO_FILE" ]; then
  echo "server_info_file_exists=true" >> "$GITHUB_OUTPUT"
fi
```

The proxy writes `{ "port": ..., "pid": ... }` once at startup. If that process later exits unexpectedly, the file can remain behind.

A subsequent action invocation using the same run/Codex-home path then:

1. sees the stale non-empty file;
2. skips `Start Responses API proxy`;
3. successfully reads the stale port from the JSON;
4. configures Codex to use a loopback endpoint where no proxy is listening.

The resulting connection failure occurs well after the action has incorrectly reported that the proxy was reusable.

## Fix

Replace the file-size-only status check with a dependency-free Node helper that validates the complete reusable state:

- server-info JSON exists and is parseable;
- `pid` is a positive integer;
- `port` is an integer in the valid TCP port range;
- the recorded process still exists (`process.kill(pid, 0)`; `EPERM` is treated as existing);
- the recorded loopback port accepts a TCP connection.

Only when all checks pass does the helper emit:

```text
server_info_file_exists=true
```

Missing, empty, malformed, dead-process, or closed-port state is reported as `false`. Stale non-empty metadata is removed so the existing proxy-start step can create a fresh server-info file.

The cleanup path first removes files normally and, on Unix, falls back to non-interactive `sudo rm` for server-info files that the action previously hardened to root ownership.

## Why check both PID and port

A process check alone is insufficient because a live process does not prove that the expected proxy listener is still available. A port check alone is also insufficient because a port can be reused by another process. Requiring both substantially narrows false reuse while keeping the check local and credential-free.

The helper does not send an HTTP request to the proxy, so it cannot accidentally trigger `/shutdown` or send application data.

## Regression coverage

Added direct Node-stdlib tests for four states:

- missing server-info file -> `false`;
- malformed server-info file -> remove it and return `false`;
- dead PID/closed port -> remove stale metadata and return `false`;
- live current PID plus a real loopback listener -> `true` and preserve the file.

The live case uses an ephemeral `net.Server`, so it exercises the same TCP-connect path as production without depending on the Codex proxy package or network access.

## Scope

This deliberately does **not** change proxy startup, API-key handling, upstream endpoint configuration, server-info format, Codex configuration, or the proxy package itself.

There are no changes under `src/`, so the checked-in `dist/main.js` bundle remains valid and does not need regeneration.

## Validation

- branch is based directly on current upstream `main` (`c385816875cc2fc8e033ed9d1cba96f8c331210e`)
- branch is 0 commits behind upstream
- diff is limited to `action.yml`, the new helper, and its focused test
- helper/test use only Node built-ins already available after the action's Node setup step

Full repository validation is left to the repository's GitHub Actions checks.

## Risk

Low. Existing healthy proxies continue to be reused. The behavior changes only when the previously trusted server-info file cannot demonstrate a live process and listener, in which case starting a new proxy is safer than configuring Codex against stale state.