### PR TITLE
fix: create custom Codex home before proxy setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -178,6 +178,19 @@ runs:
           --codex-user "$CODEX_USER" \
           --github-run-id "$CODEX_RUN_ID"
 
+    - name: Ensure Codex home exists
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        CODEX_HOME: ${{ steps.resolve_home.outputs.codex-home }}
+        SAFETY_STRATEGY: ${{ inputs['safety-strategy'] }}
+        CODEX_USER: ${{ inputs['codex-user'] }}
+      run: |
+        node "$ACTION_PATH/scripts/ensureCodexHome.mjs" \
+          "$CODEX_HOME" \
+          "$SAFETY_STRATEGY" \
+          "$CODEX_USER"
+
     - name: Determine server info path
       id: derive_server_info
       shell: bash

--- a/scripts/ensureCodexHome.mjs
+++ b/scripts/ensureCodexHome.mjs
@@ -1,5 +1,6 @@
-import { mkdir } from "node:fs/promises";
+import { access, mkdir } from "node:fs/promises";
 import { spawn } from "node:child_process";
+import path from "node:path";
 
 const [codexHome, safetyStrategy, codexUser = ""] = process.argv.slice(2);
 
@@ -14,9 +15,39 @@ if (safetyStrategy === "unprivileged-user") {
     );
   }
 
-  await run("sudo", ["-u", codexUser, "--", "mkdir", "-p", "--", codexHome]);
+  const runId = process.env.GITHUB_RUN_ID ?? "";
+  if (!runId) {
+    throw new Error(
+      "GITHUB_RUN_ID is required when preparing an unprivileged Codex home"
+    );
+  }
+
+  if (!(await pathExists(codexHome))) {
+    await run("sudo", ["mkdir", "-p", "--", codexHome]);
+    await run("sudo", ["chown", codexUser, codexHome]);
+    await run("sudo", ["chmod", "755", codexHome]);
+  }
+
+  // The proxy runs as the action's current user, while Codex runs as codexUser.
+  // Pre-create the per-run file so the proxy can write server info even when
+  // CODEX_HOME itself is owned by the unprivileged user and is not writable by
+  // the runner. The existing wait step locks this file back down to root:0444.
+  const serverInfoFile = path.join(codexHome, `${runId}.json`);
+  if (!(await pathExists(serverInfoFile))) {
+    await run("sudo", ["touch", "--", serverInfoFile]);
+    await run("sudo", ["chmod", "666", serverInfoFile]);
+  }
 } else {
   await mkdir(codexHome, { recursive: true });
+}
+
+async function pathExists(target) {
+  try {
+    await access(target);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function run(command, args) {

--- a/scripts/ensureCodexHome.mjs
+++ b/scripts/ensureCodexHome.mjs
@@ -1,0 +1,44 @@
+import { mkdir } from "node:fs/promises";
+import { spawn } from "node:child_process";
+
+const [codexHome, safetyStrategy, codexUser = ""] = process.argv.slice(2);
+
+if (!codexHome) {
+  throw new Error("Codex home path is required");
+}
+
+if (safetyStrategy === "unprivileged-user") {
+  if (!codexUser) {
+    throw new Error(
+      "codex-user is required when ensuring a Codex home for unprivileged-user"
+    );
+  }
+
+  await run("sudo", ["-u", codexUser, "--", "mkdir", "-p", "--", codexHome]);
+} else {
+  await mkdir(codexHome, { recursive: true });
+}
+
+async function run(command, args) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      env: process.env,
+      stdio: "inherit",
+    });
+
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      if (signal) {
+        reject(new Error(`${command} terminated by signal ${signal}`));
+        return;
+      }
+
+      reject(new Error(`${command} exited with code ${code}`));
+    });
+  });
+}

--- a/test/ensureCodexHome.test.mjs
+++ b/test/ensureCodexHome.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import {
   chmodSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -35,22 +36,30 @@ test("creates a missing Codex home for ordinary safety strategies", () => {
   }
 });
 
-test("creates a missing Codex home as the configured unprivileged user", () => {
+test("creates a shared unprivileged home and writable per-run server-info file", () => {
   const root = mkdtempSync(path.join(tmpdir(), "codex-home-user-test-"));
   const codexHome = path.join(root, "guest-home", ".codex");
   const fakeBin = path.join(root, "bin");
   const fakeSudo = path.join(fakeBin, "sudo");
   const logFile = path.join(root, "sudo.log");
+  const runId = "12345";
+  const serverInfoFile = path.join(codexHome, `${runId}.json`);
 
   try {
-    spawnSync("mkdir", ["-p", fakeBin], { encoding: "utf8" });
+    mkdirSync(fakeBin, { recursive: true });
     writeFileSync(
       fakeSudo,
       `#!/bin/sh
 printf '%s\n' "$*" >> "$SUDO_LOG"
-if [ "$1" = "-u" ]; then shift 2; fi
-if [ "$1" = "--" ]; then shift; fi
-exec "$@"
+case "$1" in
+  mkdir|touch)
+    exec "$@"
+    ;;
+  chown|chmod)
+    exit 0
+    ;;
+esac
+exit 2
 `,
       "utf8"
     );
@@ -65,15 +74,81 @@ exec "$@"
           ...process.env,
           PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
           SUDO_LOG: logFile,
+          GITHUB_RUN_ID: runId,
         },
       }
     );
 
     assert.equal(result.status, 0, result.stderr);
     assert.equal(existsSync(codexHome), true);
+    assert.equal(existsSync(serverInfoFile), true);
     assert.equal(
       readFileSync(logFile, "utf8"),
-      `-u guest -- mkdir -p -- ${codexHome}\n`
+      [
+        `mkdir -p -- ${codexHome}`,
+        `chown guest ${codexHome}`,
+        `chmod 755 ${codexHome}`,
+        `touch -- ${serverInfoFile}`,
+        `chmod 666 ${serverInfoFile}`,
+        "",
+      ].join("\n")
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("prepares a new run file when the unprivileged Codex home already exists", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "codex-home-existing-test-"));
+  const codexHome = path.join(root, ".codex");
+  const fakeBin = path.join(root, "bin");
+  const fakeSudo = path.join(fakeBin, "sudo");
+  const logFile = path.join(root, "sudo.log");
+  const runId = "67890";
+  const serverInfoFile = path.join(codexHome, `${runId}.json`);
+
+  try {
+    mkdirSync(codexHome, { recursive: true });
+    mkdirSync(fakeBin, { recursive: true });
+    writeFileSync(
+      fakeSudo,
+      `#!/bin/sh
+printf '%s\n' "$*" >> "$SUDO_LOG"
+case "$1" in
+  touch)
+    exec "$@"
+    ;;
+  chmod)
+    exit 0
+    ;;
+esac
+exit 2
+`,
+      "utf8"
+    );
+    chmodSync(fakeSudo, 0o755);
+
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, codexHome, "unprivileged-user", "guest"],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+          SUDO_LOG: logFile,
+          GITHUB_RUN_ID: runId,
+        },
+      }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(existsSync(serverInfoFile), true);
+    assert.equal(
+      readFileSync(logFile, "utf8"),
+      [`touch -- ${serverInfoFile}`, `chmod 666 ${serverInfoFile}`, ""].join(
+        "\n"
+      )
     );
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -88,11 +163,34 @@ test("fails clearly when unprivileged-user has no codex-user", () => {
     const result = spawnSync(
       process.execPath,
       [scriptPath, codexHome, "unprivileged-user", ""],
-      { encoding: "utf8" }
+      {
+        encoding: "utf8",
+        env: { ...process.env, GITHUB_RUN_ID: "12345" },
+      }
     );
 
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /codex-user is required/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fails clearly when an unprivileged run has no GitHub run id", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "codex-home-run-id-test-"));
+  const codexHome = path.join(root, ".codex");
+  const env = { ...process.env };
+  delete env.GITHUB_RUN_ID;
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, codexHome, "unprivileged-user", "guest"],
+      { encoding: "utf8", env }
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /GITHUB_RUN_ID is required/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/ensureCodexHome.test.mjs
+++ b/test/ensureCodexHome.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(
+  new URL("../scripts/ensureCodexHome.mjs", import.meta.url)
+);
+
+test("creates a missing Codex home for ordinary safety strategies", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "codex-home-test-"));
+  const codexHome = path.join(root, "nested", "codex-home");
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, codexHome, "drop-sudo", ""],
+      { encoding: "utf8" }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(existsSync(codexHome), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("creates a missing Codex home as the configured unprivileged user", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "codex-home-user-test-"));
+  const codexHome = path.join(root, "guest-home", ".codex");
+  const fakeBin = path.join(root, "bin");
+  const fakeSudo = path.join(fakeBin, "sudo");
+  const logFile = path.join(root, "sudo.log");
+
+  try {
+    spawnSync("mkdir", ["-p", fakeBin], { encoding: "utf8" });
+    writeFileSync(
+      fakeSudo,
+      `#!/bin/sh
+printf '%s\n' "$*" >> "$SUDO_LOG"
+if [ "$1" = "-u" ]; then shift 2; fi
+if [ "$1" = "--" ]; then shift; fi
+exec "$@"
+`,
+      "utf8"
+    );
+    chmodSync(fakeSudo, 0o755);
+
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, codexHome, "unprivileged-user", "guest"],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+          SUDO_LOG: logFile,
+        },
+      }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(existsSync(codexHome), true);
+    assert.equal(
+      readFileSync(logFile, "utf8"),
+      `-u guest -- mkdir -p -- ${codexHome}\n`
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fails clearly when unprivileged-user has no codex-user", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "codex-home-user-test-"));
+  const codexHome = path.join(root, ".codex");
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, codexHome, "unprivileged-user", ""],
+      { encoding: "utf8" }
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /codex-user is required/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Ensure the resolved Codex home is usable before proxy setup, including the shared server-info path required by `safety-strategy: unprivileged-user`.

Fixes #135.

## Problem

A user-supplied `codex-home` takes an early return from home resolution and may not exist yet. The composite action then immediately derives:

```text
$CODEX_HOME/$GITHUB_RUN_ID.json
```

and starts `codex-responses-api-proxy --server-info <that path>`. A missing parent directory causes proxy setup to fail later with `responses-api-proxy did not write server info`.

There is a second ownership boundary for `unprivileged-user`: Codex home is intentionally owned by the unprivileged account, but the Responses proxy runs as the action's current user. A `0755` home owned by the Codex user therefore does not let the proxy create a new per-run server-info file. This also affects an existing unprivileged home when a new GitHub run produces a new `$GITHUB_RUN_ID.json` path.

## Reproduction

A fresh custom path is enough:

```yaml
- uses: openai/codex-action@v1
  with:
    openai-api-key: ${{ secrets.OPENAI_API_KEY }}
    codex-home: ${{ runner.temp }}/fresh-codex-home
    prompt: Say hello.
```

For `unprivileged-user`, the same failure can occur when the Codex home already exists but the current run's server-info file does not.

## Fix

Add an explicit `Ensure Codex home exists` step immediately after home resolution.

For ordinary safety strategies, the helper recursively creates the resolved directory under the current runner identity.

For `unprivileged-user`, it mirrors the repository's existing shared-home model:

- create a missing home through `sudo mkdir -p`;
- assign the home to `codex-user` and keep mode `0755`;
- derive `$CODEX_HOME/$GITHUB_RUN_ID.json`;
- if that per-run server-info file does not exist, pre-create it and temporarily set mode `0666` so the runner-owned proxy can write it.

The existing `Wait for Responses API proxy` step already hardens that server-info file back to `root:0444` after startup.

Existing homes and existing server-info files are left untouched.

## Regression coverage

Added dependency-free Node tests covering:

1. missing nested home creation for ordinary strategies;
2. creation of a new unprivileged home plus its writable per-run server-info file;
3. an already-existing unprivileged home receiving a new server-info file for a new GitHub run;
4. a clear error when `codex-user` is missing;
5. a clear error when `GITHUB_RUN_ID` is unavailable for the shared-file path.

The privilege tests use a fake `sudo` executable so exact command boundaries are asserted without requiring elevated local privileges.

## Validation

- all **5/5** focused behavioural tests pass locally with Node's built-in test runner;
- branch is based directly on current upstream `main` (`c385816875cc2fc8e033ed9d1cba96f8c331210e`);
- no files under `src/` are changed, so the checked-in `dist/main.js` bundle remains valid;
- scope remains limited to `action.yml`, `scripts/ensureCodexHome.mjs`, and `test/ensureCodexHome.test.mjs`.

## Risk

Low. Existing valid homes and existing server-info files retain their current ownership and permissions. The new behaviour only prepares missing state that the action already expects to use, and follows the same temporary server-info permission model already used by the built-in unprivileged-home path.