### PR TITLE
fix: clean temporary Codex output after failed runs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -329,13 +329,27 @@ runs:
         fi
         echo "Confirmed sudo privilege is disabled."
 
+    - name: Prepare managed Codex output
+      id: managed_output
+      if: ${{ (inputs.prompt != '' || inputs['prompt-file'] != '') && inputs['output-file'] == '' }}
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        SAFETY_STRATEGY: ${{ inputs['safety-strategy'] }}
+        CODEX_USER: ${{ inputs['codex-user'] }}
+      run: |
+        node "$ACTION_PATH/scripts/manageCodexOutput.mjs" \
+          prepare \
+          "$SAFETY_STRATEGY" \
+          "$CODEX_USER"
+
     - name: Run codex exec
       id: run_codex
       if: ${{ inputs.prompt != '' || inputs['prompt-file'] != '' }}
       env:
         CODEX_PROMPT: ${{ inputs.prompt }}
         CODEX_PROMPT_FILE: ${{ inputs['prompt-file'] }}
-        CODEX_OUTPUT_FILE: ${{ inputs['output-file'] }}
+        CODEX_OUTPUT_FILE: ${{ inputs['output-file'] || steps.managed_output.outputs.output_file }}
         CODEX_HOME: ${{ steps.resolve_home.outputs.codex-home }}
         CODEX_WORKING_DIRECTORY: ${{ inputs['working-directory'] || github.workspace }}
         CODEX_SANDBOX: ${{ inputs.sandbox }}
@@ -366,3 +380,17 @@ runs:
             --effort "$CODEX_EFFORT" \
             --safety-strategy "$CODEX_SAFETY_STRATEGY" \
             --codex-user "$CODEX_USER"
+
+    - name: Clean managed Codex output
+      if: ${{ always() && steps.managed_output.outputs.output_dir != '' }}
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        CODEX_MANAGED_OUTPUT_DIR: ${{ steps.managed_output.outputs.output_dir }}
+        SAFETY_STRATEGY: ${{ inputs['safety-strategy'] }}
+        CODEX_USER: ${{ inputs['codex-user'] }}
+      run: |
+        node "$ACTION_PATH/scripts/manageCodexOutput.mjs" \
+          cleanup \
+          "$SAFETY_STRATEGY" \
+          "$CODEX_USER"

--- a/scripts/manageCodexOutput.mjs
+++ b/scripts/manageCodexOutput.mjs
@@ -1,0 +1,126 @@
+import { appendFile, mkdtemp, rm } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+
+const [operation, safetyStrategy, codexUser = ""] = process.argv.slice(2);
+
+switch (operation) {
+  case "prepare":
+    await prepareOutput();
+    break;
+  case "cleanup":
+    await cleanupOutput();
+    break;
+  default:
+    throw new Error("Expected operation to be 'prepare' or 'cleanup'");
+}
+
+async function prepareOutput() {
+  let dir;
+  if (safetyStrategy === "unprivileged-user") {
+    if (!codexUser) {
+      throw new Error(
+        "codex-user is required when preparing output for unprivileged-user"
+      );
+    }
+    dir = (
+      await capture("sudo", [
+        "-u",
+        codexUser,
+        "--",
+        "mktemp",
+        "-d",
+        "-t",
+        "codex-action-output.XXXXXX",
+      ])
+    ).trim();
+  } else {
+    dir = await mkdtemp(path.join(os.tmpdir(), "codex-action-output-"));
+  }
+
+  if (!dir) {
+    throw new Error("Could not create managed Codex output directory");
+  }
+
+  const outputFile = path.join(dir, "output.md");
+  const githubOutput = process.env.GITHUB_OUTPUT;
+  if (!githubOutput) {
+    await removeDirectory(dir);
+    throw new Error("GITHUB_OUTPUT is required to publish managed output paths");
+  }
+
+  try {
+    await appendFile(
+      githubOutput,
+      `output_file=${outputFile}\noutput_dir=${dir}\n`,
+      "utf8"
+    );
+  } catch (error) {
+    await removeDirectory(dir);
+    throw error;
+  }
+}
+
+async function cleanupOutput() {
+  const dir = process.env.CODEX_MANAGED_OUTPUT_DIR ?? "";
+  if (!dir) {
+    return;
+  }
+  await removeDirectory(dir);
+}
+
+async function removeDirectory(dir) {
+  if (safetyStrategy === "unprivileged-user") {
+    await run("sudo", ["rm", "-rf", "--", dir]);
+  } else {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function capture(command, args) {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      env: process.env,
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+
+    let output = "";
+    child.stdout.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      if (code === 0) {
+        resolve(output);
+        return;
+      }
+      reject(exitError(command, code, signal));
+    });
+  });
+}
+
+async function run(command, args) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      env: process.env,
+      stdio: "inherit",
+    });
+
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(exitError(command, code, signal));
+    });
+  });
+}
+
+function exitError(command, code, signal) {
+  if (signal) {
+    return new Error(`${command} terminated by signal ${signal}`);
+  }
+  return new Error(`${command} exited with code ${code}`);
+}

--- a/test/manageCodexOutput.test.mjs
+++ b/test/manageCodexOutput.test.mjs
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(
+  new URL("../scripts/manageCodexOutput.mjs", import.meta.url)
+);
+
+function parseOutputs(file) {
+  return Object.fromEntries(
+    readFileSync(file, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => {
+        const index = line.indexOf("=");
+        return [line.slice(0, index), line.slice(index + 1)];
+      })
+  );
+}
+
+test("prepares and cleans runner-owned output", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "managed-output-test-"));
+  const githubOutput = path.join(root, "github-output");
+  writeFileSync(githubOutput, "", "utf8");
+
+  try {
+    const prepare = spawnSync(
+      process.execPath,
+      [scriptPath, "prepare", "drop-sudo", ""],
+      {
+        encoding: "utf8",
+        env: { ...process.env, GITHUB_OUTPUT: githubOutput, TMPDIR: root },
+      }
+    );
+    assert.equal(prepare.status, 0, prepare.stderr);
+
+    const outputs = parseOutputs(githubOutput);
+    assert.ok(outputs.output_file);
+    assert.ok(outputs.output_dir);
+    assert.equal(existsSync(outputs.output_dir), true);
+    assert.equal(path.dirname(outputs.output_file), outputs.output_dir);
+
+    const cleanup = spawnSync(
+      process.execPath,
+      [scriptPath, "cleanup", "drop-sudo", ""],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CODEX_MANAGED_OUTPUT_DIR: outputs.output_dir,
+        },
+      }
+    );
+    assert.equal(cleanup.status, 0, cleanup.stderr);
+    assert.equal(existsSync(outputs.output_dir), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("uses the configured user for unprivileged output and root cleanup", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "managed-output-user-test-"));
+  const fakeBin = path.join(root, "bin");
+  const fakeSudo = path.join(fakeBin, "sudo");
+  const githubOutput = path.join(root, "github-output");
+  const logFile = path.join(root, "sudo.log");
+  mkdirSync(fakeBin, { recursive: true });
+  writeFileSync(githubOutput, "", "utf8");
+  writeFileSync(
+    fakeSudo,
+    `#!/bin/sh
+printf '%s\n' "$*" >> "$SUDO_LOG"
+if [ "$1" = "-u" ]; then
+  shift 2
+  if [ "$1" = "--" ]; then shift; fi
+  exec "$@"
+fi
+if [ "$1" = "rm" ]; then
+  exec "$@"
+fi
+exit 2
+`,
+    "utf8"
+  );
+  chmodSync(fakeSudo, 0o755);
+
+  try {
+    const env = {
+      ...process.env,
+      PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+      SUDO_LOG: logFile,
+      GITHUB_OUTPUT: githubOutput,
+      TMPDIR: root,
+    };
+    const prepare = spawnSync(
+      process.execPath,
+      [scriptPath, "prepare", "unprivileged-user", "guest"],
+      { encoding: "utf8", env }
+    );
+    assert.equal(prepare.status, 0, prepare.stderr);
+
+    const outputs = parseOutputs(githubOutput);
+    assert.equal(existsSync(outputs.output_dir), true);
+
+    const cleanup = spawnSync(
+      process.execPath,
+      [scriptPath, "cleanup", "unprivileged-user", "guest"],
+      {
+        encoding: "utf8",
+        env: { ...env, CODEX_MANAGED_OUTPUT_DIR: outputs.output_dir },
+      }
+    );
+    assert.equal(cleanup.status, 0, cleanup.stderr);
+    assert.equal(existsSync(outputs.output_dir), false);
+
+    const log = readFileSync(logFile, "utf8");
+    assert.match(log, /-u guest -- mktemp -d -t codex-action-output\.XXXXXX/);
+    assert.match(log, new RegExp(`rm -rf -- ${outputs.output_dir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("fails before creating output when unprivileged-user has no codex-user", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "managed-output-user-test-"));
+  const githubOutput = path.join(root, "github-output");
+  writeFileSync(githubOutput, "", "utf8");
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath, "prepare", "unprivileged-user", ""],
+      {
+        encoding: "utf8",
+        env: { ...process.env, GITHUB_OUTPUT: githubOutput },
+      }
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /codex-user is required/);
+    assert.equal(readFileSync(githubOutput, "utf8"), "");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Make the composite action own the implicit `--output-last-message` file lifecycle so temporary output is removed even when `codex exec` fails.

Fixes #137.

## Problem

When the user does not set `output-file`, the bundled `run-codex-exec` helper creates a temporary directory internally.

That directory is cleaned from `finalizeExecution()`, but `finalizeExecution()` is only reached after a zero exit code. A non-zero Codex exit rejects immediately, leaving the action-owned temporary directory behind.

On ephemeral hosted runners this is mostly noise. On long-lived self-hosted runners, repeated failed runs can accumulate abandoned temporary directories.

## Fix

Move ownership of the implicit output path to the composite-action boundary:

1. When a prompt is being run and the caller did **not** provide `output-file`, create a managed temporary directory before invoking Codex.
2. Pass its `output.md` path through the helper's existing explicit `--output-file` option.
3. Add an `always()` cleanup step after `Run codex exec`.

Because the helper sees an explicit output path, it no longer creates its own untracked temporary output directory. The action can therefore clean the managed directory after success, validation errors, process failures, or non-zero Codex exits.

User-provided `output-file` paths are not managed or deleted.

## Privilege handling

The helper preserves the existing safety-strategy boundary:

- ordinary strategies use Node's `mkdtemp` / recursive `rm` under the current runner identity;
- `unprivileged-user` creates the directory through `sudo -u <codex-user> -- mktemp -d`, so Codex can write the final message;
- cleanup for that path uses `sudo rm -rf` because the directory is owned by the unprivileged account.

`drop-sudo` remains safe because its managed directory is runner-owned and cleanup does not require sudo after privilege removal.

## Regression coverage

Added dependency-free Node tests covering:

- prepare + cleanup for a runner-owned temporary output path;
- exact `sudo -u <user>` preparation and privileged cleanup for `unprivileged-user`;
- fail-fast validation when `unprivileged-user` is selected without `codex-user`.

The unprivileged test uses a fake `sudo` executable and a real temporary directory, so both command construction and actual cleanup are exercised without elevated test privileges.

## Validation

- all **3/3** focused behavioural tests pass locally with Node's built-in test runner;
- branch is based directly on current upstream `main` (`c385816875cc2fc8e033ed9d1cba96f8c331210e`);
- branch is 0 commits behind upstream;
- no files under `src/` change, so the checked-in `dist/main.js` remains valid;
- production manifest diff is 29 additions / 1 deletion, with the remaining changes isolated to the helper and focused tests.

## Risk

Low. The existing `run-codex-exec` interface is unchanged. Explicit user output files keep their current behavior. The only behavioral change is that the action supplies and later removes its own temporary output path when the caller left `output-file` empty.