### PR TITLE
fix: reject conflicting inputs before setup side effects

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -136,6 +136,19 @@ runs:
       with:
         node-version: "24"
 
+    - name: Validate action inputs
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        CODEX_PROMPT: ${{ inputs.prompt }}
+        CODEX_PROMPT_FILE: ${{ inputs['prompt-file'] }}
+        CODEX_OUTPUT_SCHEMA: ${{ inputs['output-schema'] }}
+        CODEX_OUTPUT_SCHEMA_FILE: ${{ inputs['output-schema-file'] }}
+        CODEX_SANDBOX: ${{ inputs.sandbox }}
+        CODEX_PERMISSION_PROFILE: ${{ inputs['permission-profile'] }}
+        CODEX_SAFETY_STRATEGY: ${{ inputs['safety-strategy'] }}
+      run: node "$ACTION_PATH/scripts/validateActionInputs.mjs"
+
     - name: Check repository write access
       env:
         ACTION_PATH: ${{ github.action_path }}

--- a/scripts/validateActionInputs.mjs
+++ b/scripts/validateActionInputs.mjs
@@ -1,0 +1,31 @@
+const value = (name) => (process.env[name] ?? "").trim();
+
+const prompt = value("CODEX_PROMPT");
+const promptFile = value("CODEX_PROMPT_FILE");
+const outputSchema = value("CODEX_OUTPUT_SCHEMA");
+const outputSchemaFile = value("CODEX_OUTPUT_SCHEMA_FILE");
+const sandbox = value("CODEX_SANDBOX");
+const permissionProfile = value("CODEX_PERMISSION_PROFILE");
+const safetyStrategy = value("CODEX_SAFETY_STRATEGY");
+
+if (prompt && promptFile) {
+  throw new Error("Only one of `prompt` or `prompt-file` may be specified.");
+}
+
+if (outputSchema && outputSchemaFile) {
+  throw new Error(
+    "Only one of `output-schema` or `output-schema-file` may be specified."
+  );
+}
+
+if (permissionProfile && sandbox) {
+  throw new Error(
+    "`permission-profile` and `sandbox` are mutually exclusive. Permission profiles do not compose with legacy sandbox settings."
+  );
+}
+
+if (permissionProfile && safetyStrategy === "read-only") {
+  throw new Error(
+    "`permission-profile` cannot be combined with the `read-only` safety strategy because that strategy forces the legacy read-only sandbox."
+  );
+}

--- a/test/validateActionInputs.test.mjs
+++ b/test/validateActionInputs.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(
+  new URL("../scripts/validateActionInputs.mjs", import.meta.url)
+);
+
+function run(overrides = {}) {
+  return spawnSync(process.execPath, [scriptPath], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CODEX_PROMPT: "",
+      CODEX_PROMPT_FILE: "",
+      CODEX_OUTPUT_SCHEMA: "",
+      CODEX_OUTPUT_SCHEMA_FILE: "",
+      CODEX_SANDBOX: "",
+      CODEX_PERMISSION_PROFILE: "",
+      CODEX_SAFETY_STRATEGY: "drop-sudo",
+      ...overrides,
+    },
+  });
+}
+
+test("accepts compatible inputs", () => {
+  const result = run({ CODEX_PROMPT: "Review this change" });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("treats whitespace-only values as empty", () => {
+  const result = run({
+    CODEX_PROMPT: "   ",
+    CODEX_PROMPT_FILE: ".github/codex-prompt.md",
+  });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("rejects prompt with prompt-file", () => {
+  const result = run({
+    CODEX_PROMPT: "Review this change",
+    CODEX_PROMPT_FILE: ".github/codex-prompt.md",
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Only one of `prompt` or `prompt-file`/);
+});
+
+test("rejects output-schema with output-schema-file", () => {
+  const result = run({
+    CODEX_OUTPUT_SCHEMA: '{"type":"object"}',
+    CODEX_OUTPUT_SCHEMA_FILE: "schema.json",
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stderr,
+    /Only one of `output-schema` or `output-schema-file`/
+  );
+});
+
+test("rejects permission-profile with sandbox", () => {
+  const result = run({
+    CODEX_PERMISSION_PROFILE: "public-review",
+    CODEX_SANDBOX: "read-only",
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /mutually exclusive/);
+});
+
+test("rejects permission-profile with read-only safety strategy", () => {
+  const result = run({
+    CODEX_PERMISSION_PROFILE: "public-review",
+    CODEX_SAFETY_STRATEGY: "read-only",
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /forces the legacy read-only sandbox/);
+});


### PR DESCRIPTION
## Summary

Reject known-invalid input combinations immediately after Node setup, before the action starts the proxy, changes host configuration, or irreversibly drops sudo.

Fixes #139.

## Problem

The final `run-codex-exec` helper already validates several mutually exclusive inputs, but those checks happen very late in the composite action.

For example, setting both:

```yaml
prompt: Review this change
prompt-file: .github/codex-prompt.md
```

is guaranteed to fail, but the action currently reaches that error only after setup steps that may include:

- package installation;
- Responses API proxy startup;
- Linux user-namespace/AppArmor changes;
- `drop-sudo`, which is intentionally irreversible for the remainder of the job.

The same ordering applies to other conflicts the helper already knows how to reject.

## Fix

Add a small dependency-free preflight immediately after `Ensure Node.js available` and before repository checks or other side effects.

The preflight mirrors the helper's simple deterministic conflicts:

- `prompt` + `prompt-file`;
- `output-schema` + `output-schema-file`;
- `permission-profile` + `sandbox`;
- `permission-profile` + `safety-strategy: read-only`.

Values are trimmed before the check, matching the helper's existing `emptyAsNull` semantics, so whitespace-only values remain equivalent to empty inputs.

The validation inside `dist/main.js` remains unchanged as defense in depth and for callers that invoke the helper command directly.

## Why this belongs before setup

None of these checks needs repository contents, credentials, network access, a running proxy, or modified host state. Failing after those operations provides no additional information and can leave the job changed even though Codex could never have run.

## Regression coverage

Added six direct Node-stdlib tests covering:

1. compatible inputs succeed;
2. whitespace-only values are treated as empty;
3. `prompt` + `prompt-file` fails;
4. `output-schema` + `output-schema-file` fails;
5. `permission-profile` + `sandbox` fails;
6. `permission-profile` + `read-only` safety strategy fails.

## Validation

- all **6/6** focused behavioural tests pass locally with Node's built-in test runner;
- branch is based directly on current upstream `main` (`c385816875cc2fc8e033ed9d1cba96f8c331210e`);
- branch is 0 commits behind upstream;
- production manifest change is only **13 added lines**;
- no files under `src/` change, so the checked-in `dist/main.js` bundle remains valid.

## Risk

Low. These configurations already fail today. The only behaviour change is **when** they fail: before side effects instead of after them.