### PR TITLE
fix: validate prompt and working paths before setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -136,6 +136,14 @@ runs:
       with:
         node-version: "24"
 
+    - name: Validate action paths
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        CODEX_PROMPT_FILE: ${{ inputs['prompt-file'] }}
+        CODEX_WORKING_DIRECTORY: ${{ inputs['working-directory'] || github.workspace }}
+      run: node "$ACTION_PATH/scripts/validateActionPaths.mjs"
+
     - name: Check repository write access
       env:
         ACTION_PATH: ${{ github.action_path }}

--- a/scripts/validateActionPaths.mjs
+++ b/scripts/validateActionPaths.mjs
@@ -1,0 +1,46 @@
+import { access, stat } from "node:fs/promises";
+import { constants } from "node:fs";
+
+const promptFile = (process.env.CODEX_PROMPT_FILE ?? "").trim();
+const workingDirectory = (process.env.CODEX_WORKING_DIRECTORY ?? "").trim();
+
+if (promptFile) {
+  await requireReadableFile("prompt-file", promptFile);
+}
+
+if (!workingDirectory) {
+  throw new Error("working-directory resolved to an empty path");
+}
+await requireDirectory("working-directory", workingDirectory);
+
+async function requireReadableFile(label, target) {
+  let info;
+  try {
+    info = await stat(target);
+  } catch {
+    throw new Error(`${label} does not exist: ${target}`);
+  }
+
+  if (info.isDirectory()) {
+    throw new Error(`${label} must reference a file, not a directory: ${target}`);
+  }
+
+  try {
+    await access(target, constants.R_OK);
+  } catch {
+    throw new Error(`${label} is not readable: ${target}`);
+  }
+}
+
+async function requireDirectory(label, target) {
+  let info;
+  try {
+    info = await stat(target);
+  } catch {
+    throw new Error(`${label} does not exist: ${target}`);
+  }
+
+  if (!info.isDirectory()) {
+    throw new Error(`${label} must reference a directory: ${target}`);
+  }
+}

--- a/test/validateActionPaths.test.mjs
+++ b/test/validateActionPaths.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(
+  new URL("../scripts/validateActionPaths.mjs", import.meta.url)
+);
+
+function run({ promptFile = "", workingDirectory }) {
+  return spawnSync(process.execPath, [scriptPath], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CODEX_PROMPT_FILE: promptFile,
+      CODEX_WORKING_DIRECTORY: workingDirectory,
+    },
+  });
+}
+
+test("accepts a readable prompt file and existing working directory", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "codex-path-test-"));
+  const promptFile = path.join(root, "prompt.md");
+  writeFileSync(promptFile, "Review this change", "utf8");
+
+  try {
+    const result = run({ promptFile, workingDirectory: root });
+    assert.equal(result.status, 0, result.stderr);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("allows an empty prompt-file when inline prompt is used", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "codex-path-test-"));
+  try {
+    const result = run({ promptFile: "   ", workingDirectory: root });
+    assert.equal(result.status, 0, result.stderr);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects a missing prompt-file", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "codex-path-test-"));
+  const promptFile = path.join(root, "missing.md");
+
+  try {
+    const result = run({ promptFile, workingDirectory: root });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /prompt-file does not exist/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects a directory used as prompt-file", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "codex-path-test-"));
+  const promptDirectory = path.join(root, "prompt-dir");
+  mkdirSync(promptDirectory);
+
+  try {
+    const result = run({
+      promptFile: promptDirectory,
+      workingDirectory: root,
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /prompt-file must reference a file/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects a missing working-directory", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "codex-path-test-"));
+  const missingDirectory = path.join(root, "missing");
+
+  try {
+    const result = run({ workingDirectory: missingDirectory });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /working-directory does not exist/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects a file used as working-directory", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "codex-path-test-"));
+  const filePath = path.join(root, "not-a-directory");
+  writeFileSync(filePath, "x", "utf8");
+
+  try {
+    const result = run({ workingDirectory: filePath });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /working-directory must reference a directory/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Validate local path inputs immediately after Node setup so missing `prompt-file` or invalid `working-directory` values fail before proxy startup and irreversible host changes.

Fixes #141.

## Problem

`prompt-file` is not read until the final `run-codex-exec` helper starts, and `working-directory` is not meaningfully checked until Codex is invoked.

That ordering means a simple path typo can be reported only after the action has already performed setup that may include:

- package installation;
- Responses API proxy startup;
- Linux user-namespace/AppArmor changes;
- the default irreversible `drop-sudo` step.

For example:

```yaml
- uses: openai/codex-action@v1
  with:
    openai-api-key: ${{ secrets.OPENAI_API_KEY }}
    prompt-file: .github/does-not-exist.md
```

currently reaches `readFile(prompt.path, "utf8")` near the end of the action, after those setup steps.

## Fix

Add a dependency-free filesystem preflight immediately after Node setup.

It validates:

- a non-empty `prompt-file` exists, is not a directory, and is readable by the action process;
- the effective `working-directory` (`input` or `github.workspace`) exists and is a directory.

Whitespace-only `prompt-file` remains equivalent to an empty value, matching the action's existing input normalization behavior.

The existing runtime checks remain in place, so races or filesystem changes after preflight still fail normally.

## Scope

This intentionally does not preflight `output-schema-file` or `output-file`: those paths are consumed by Codex and can have different ownership/relative-path semantics under `unprivileged-user` and `--cd`. This PR only validates paths whose interpretation is unambiguous at the composite-action boundary.

## Regression coverage

Added six Node-stdlib tests covering:

1. readable prompt file + valid working directory;
2. empty/whitespace prompt-file with inline prompt usage;
3. missing prompt-file;
4. directory passed as prompt-file;
5. missing working-directory;
6. file passed as working-directory.

## Validation

- all **6/6** focused behavioural tests pass locally;
- branch is based directly on current upstream `main` (`c385816875cc2fc8e033ed9d1cba96f8c331210e`);
- branch is 0 commits behind upstream;
- production manifest change is only **8 added lines**;
- no files under `src/` change, so the checked-in `dist/main.js` bundle remains valid.

## Risk

Low. These invalid paths already fail today. The change moves deterministic filesystem failures earlier, before the action mutates runner state.