### PR TITLE
fix: detach Responses proxy stdio on container runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -211,6 +211,7 @@ runs:
       env:
         SERVER_INFO_FILE: ${{ steps.derive_server_info.outputs.server_info_file }}
         PROXY_API_KEY: ${{ inputs['openai-api-key'] }}
+        PROXY_LOG_FILE: ${{ runner.temp }}/codex-responses-api-proxy-${{ github.run_id }}.log
         UPSTREAM_URL: ${{ inputs['responses-api-endpoint'] }}
       shell: bash
       run: |
@@ -226,12 +227,13 @@ runs:
 
         (
           printenv PROXY_API_KEY | env -u PROXY_API_KEY "${args[@]}"
-        ) &
+        ) >>"$PROXY_LOG_FILE" 2>&1 &
 
     - name: Wait for Responses API proxy
       if: ${{ inputs['openai-api-key'] != '' && steps.start_proxy.outputs.server_info_file_exists == 'false' }}
       shell: bash
       env:
+        PROXY_LOG_FILE: ${{ runner.temp }}/codex-responses-api-proxy-${{ github.run_id }}.log
         SERVER_INFO_FILE: ${{ steps.derive_server_info.outputs.server_info_file }}
       run: |
         for _ in {1..10}; do
@@ -242,6 +244,10 @@ runs:
         done
         if [ ! -s "$SERVER_INFO_FILE" ]; then
           echo "responses-api-proxy did not write server info" >&2
+          if [ -s "$PROXY_LOG_FILE" ]; then
+            echo "Responses API proxy log:" >&2
+            cat "$PROXY_LOG_FILE" >&2
+          fi
           exit 1
         fi
 

--- a/test/proxyStdio.test.mjs
+++ b/test/proxyStdio.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const actionPath = fileURLToPath(new URL("../action.yml", import.meta.url));
+
+async function actionSource() {
+  return await readFile(actionPath, "utf8");
+}
+
+test("background proxy redirects stdout and stderr away from the step stream", async () => {
+  const source = await actionSource();
+
+  assert.match(
+    source,
+    /printenv PROXY_API_KEY \| env -u PROXY_API_KEY "\$\{args\[@\]\}"\n\s*\) >>"\$PROXY_LOG_FILE" 2>&1 &/
+  );
+  assert.match(
+    source,
+    /PROXY_LOG_FILE: \$\{\{ runner\.temp \}\}\/codex-responses-api-proxy-\$\{\{ github\.run_id \}\}\.log/
+  );
+});
+
+test("proxy startup failure prints the detached log", async () => {
+  const source = await actionSource();
+
+  assert.match(source, /responses-api-proxy did not write server info/);
+  assert.match(source, /cat "\$PROXY_LOG_FILE" >&2/);
+});


### PR DESCRIPTION
## Summary

Detach the long-lived Responses API proxy from the GitHub Actions step stdout/stderr stream so container-based runners such as ARC do not keep the step transport open after Bash exits.

Fixes #108.

## Problem

`Start Responses API proxy` currently backgrounds the proxy without redirecting its output:

```bash
(
  printenv PROXY_API_KEY | env -u PROXY_API_KEY "${args[@]}"
) &
```

On ordinary GitHub-hosted runners, that background process can outlive the shell without blocking the next step.

On container runners that execute steps through a persistent exec/WebSocket transport, the proxy inherits the step's stdout/stderr file descriptors. The shell exits, but the long-lived proxy keeps those descriptors open, so the runner can treat the step transport as still active and eventually time out before the next step starts.

## Fix

Redirect the proxy's stdout and stderr to a per-run log under `runner.temp` before backgrounding it:

```bash
) >>"$PROXY_LOG_FILE" 2>&1 &
```

The log path is:

```text
${{ runner.temp }}/codex-responses-api-proxy-${{ github.run_id }}.log
```

This removes the inherited step-stream descriptors while preserving diagnostics.

If the proxy never writes its server-info file, the existing wait step now prints the detached proxy log to stderr before failing, so startup errors remain visible.

## Why no `disown`

The failure mode in #108 is the inherited stdout/stderr transport, not Bash job-table ownership. The action already backgrounds the process successfully on current runners. Redirecting those descriptors addresses the container-exec hang without adding shell job-control assumptions.

## Regression coverage

Added a focused Node-stdlib manifest test that verifies:

- the background proxy invocation redirects both stdout and stderr to the per-run log;
- the log path is rooted in `runner.temp` and scoped by `github.run_id`;
- proxy startup failure emits the detached log before exiting.

## Validation

- branch is based directly on current upstream `main` (`c385816875cc2fc8e033ed9d1cba96f8c331210e`);
- branch is 0 commits behind upstream;
- production diff is **7 additions / 1 deletion** in `action.yml`;
- no files under `src/` change, so the checked-in `dist/main.js` bundle remains valid.

## Risk

Low. Proxy lifetime, API-key handling, server-info format, port selection, and upstream endpoint behavior are unchanged. The only runtime change is where the background proxy writes stdout/stderr.