### PR TITLE
docs: add GitHub MCP setup for Actions

### DIFF
--- a/docs/github-mcp.md
+++ b/docs/github-mcp.md
@@ -1,0 +1,78 @@
+# Using the GitHub MCP server
+
+`codex-action` can use MCP servers configured in the selected Codex home. For GitHub automation, the simplest setup is GitHub's remote MCP server together with a GitHub token exposed only to the Codex step.
+
+The OpenAI API key and the GitHub token serve different purposes:
+
+- `openai-api-key` authenticates Codex model requests through the action's Responses proxy.
+- `GITHUB_TOKEN` authenticates the GitHub MCP server.
+
+## Example
+
+The workflow below gives the MCP server read access to repository contents and write access to pull requests. Narrow the `permissions` block further when the task does not need to write to GitHub.
+
+```yaml
+name: Codex review with GitHub MCP
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Configure GitHub MCP
+        shell: bash
+        env:
+          CODEX_HOME: ${{ runner.temp }}/codex-home
+        run: |
+          mkdir -p "$CODEX_HOME"
+          cat > "$CODEX_HOME/config.toml" <<'EOF'
+          [mcp_servers.github]
+          url = "https://api.githubcopilot.com/mcp/"
+          bearer_token_env_var = "GITHUB_TOKEN"
+          required = true
+          EOF
+
+      - name: Run Codex
+        uses: openai/codex-action@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          codex-home: ${{ runner.temp }}/codex-home
+          prompt: |
+            Review this pull request. Use the GitHub MCP tools when you need
+            repository or pull-request context.
+```
+
+The action preserves the caller's existing `config.toml` when it adds its own Responses proxy configuration, so the MCP server entry remains available to `codex exec`.
+
+## Using a separate GitHub token
+
+If the job needs permissions that you do not want to grant to the workflow's generated token, store a dedicated token as a GitHub secret and expose it under the environment variable named by `bearer_token_env_var`:
+
+```yaml
+env:
+  GITHUB_TOKEN: ${{ secrets.CODEX_GITHUB_TOKEN }}
+```
+
+Grant that token only the repository permissions required by the MCP tools you intend Codex to use.
+
+## Local GitHub MCP server
+
+GitHub also publishes a local MCP server that can run through Docker or as a binary. To use that form, configure a normal Codex stdio MCP server in `config.toml` with `command`, `args`, and any required environment variables. The remote configuration above avoids installing or managing another long-lived process in the Actions job.
+
+## Troubleshooting
+
+- If Codex can see the MCP server but GitHub writes fail, check the workflow `permissions` block or the permissions on the token supplied as `GITHUB_TOKEN`.
+- If the MCP server fails to initialize, keep `required = true` while debugging so `codex exec` fails instead of silently continuing without GitHub tools.
+- If you use a custom `codex-home`, create its `config.toml` before invoking `codex-action` and pass the same path through the `codex-home` input.
+
+See GitHub's `github/github-mcp-server` repository for the remote server's authentication and toolset options, and the Codex configuration reference for additional MCP settings such as tool allow-lists and timeouts.

--- a/examples/github-mcp.yml
+++ b/examples/github-mcp.yml
@@ -1,0 +1,38 @@
+name: "Example: Use GitHub MCP from Codex"
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  run-codex-with-github-mcp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Configure GitHub MCP
+        shell: bash
+        env:
+          CODEX_HOME: ${{ runner.temp }}/codex-home
+        run: |
+          mkdir -p "$CODEX_HOME"
+          cat > "$CODEX_HOME/config.toml" <<'EOF'
+          [mcp_servers.github]
+          url = "https://api.githubcopilot.com/mcp/"
+          bearer_token_env_var = "GITHUB_TOKEN"
+          required = true
+          EOF
+
+      - name: Run Codex with GitHub MCP
+        uses: openai/codex-action@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          codex-home: ${{ runner.temp }}/codex-home
+          prompt: |
+            Inspect this repository and use the GitHub MCP tools when GitHub
+            context is useful. Do not make GitHub changes unless the task
+            explicitly requires them.


### PR DESCRIPTION
## Summary

Document how to configure GitHub's MCP server for `codex-action`, including a copyable workflow example that uses the job's GitHub token with explicit permissions.

Fixes #60.

## Problem

The README currently mentions MCP only as a general suggestion. It does not show how an Actions user should:

- configure an MCP server in the Codex home used by the action;
- pass GitHub authentication to that server;
- keep the OpenAI API key separate from the GitHub credential;
- grant the workflow enough GitHub permissions for MCP write operations.

That leaves users asking how to give Codex GitHub MCP access from the Action without a supported example to follow.

## Documentation added

`docs/github-mcp.md` provides a complete remote-server setup using the current Codex MCP config shape:

```toml
[mcp_servers.github]
url = "https://api.githubcopilot.com/mcp/"
bearer_token_env_var = "GITHUB_TOKEN"
required = true
```

The workflow exposes `github.token` only as `GITHUB_TOKEN` for the Codex step and passes the same prepared home through `codex-home`.

The guide also explains:

- the distinct roles of `openai-api-key` and the GitHub credential;
- least-privilege workflow permissions;
- replacing `github.token` with a dedicated secret when needed;
- local-vs-remote GitHub MCP options;
- common initialization and permission troubleshooting.

`examples/github-mcp.yml` contains the same pattern as a standalone workflow example.

## Verification

The example is based on the current public interfaces of both projects:

- Codex supports remote MCP configuration through `mcp_servers.<name>.url` and `bearer_token_env_var`;
- GitHub's official MCP server documents `https://api.githubcopilot.com/mcp/` as its remote endpoint and supports token authentication;
- `codex-action` already preserves caller-provided Codex configuration when adding its Responses proxy settings.

No runtime code, action inputs, generated bundle, or security behavior changes.

## Scope

Documentation and example workflow only. This PR does not install a local MCP process, add new action inputs, broaden `GITHUB_TOKEN` permissions automatically, or change the action's write-access guard.