### PR TITLE
fix: isolate Responses proxy state by run attempt

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -170,7 +170,7 @@ runs:
         CODEX_HOME_OVERRIDE: ${{ inputs['codex-home'] }}
         SAFETY_STRATEGY: ${{ inputs['safety-strategy'] }}
         CODEX_USER: ${{ inputs['codex-user'] }}
-        CODEX_RUN_ID: ${{ github.run_id }}
+        CODEX_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
       run: |
         node "$ACTION_PATH/dist/main.js" resolve-codex-home \
           --codex-home-override "$CODEX_HOME_OVERRIDE" \
@@ -183,7 +183,7 @@ runs:
       shell: bash
       env:
         CODEX_HOME: ${{ steps.resolve_home.outputs.codex-home }}
-        CODEX_RUN_ID: ${{ github.run_id }}
+        CODEX_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
       run: |
         server_info_file="$CODEX_HOME/$CODEX_RUN_ID.json"
         echo "server_info_file=$server_info_file" >> "$GITHUB_OUTPUT"

--- a/test/runAttemptState.test.mjs
+++ b/test/runAttemptState.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const actionPath = fileURLToPath(new URL("../action.yml", import.meta.url));
+
+test("server-info state includes the GitHub run attempt", async () => {
+  const source = await readFile(actionPath, "utf8");
+  const expected =
+    "CODEX_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}";
+
+  assert.equal(source.split(expected).length - 1, 2);
+  assert.doesNotMatch(
+    source,
+    /^\s*CODEX_RUN_ID: \$\{\{ github\.run_id \}\}\s*$/m
+  );
+  assert.match(source, /server_info_file="\$CODEX_HOME\/\$CODEX_RUN_ID\.json"/);
+});


### PR DESCRIPTION
## Summary

Include `github.run_attempt` in the Responses proxy server-info key so a workflow re-run cannot collide with proxy metadata from an earlier attempt of the same run.

Fixes #144.

## Problem

The action currently derives proxy state from:

```text
$CODEX_HOME/$GITHUB_RUN_ID.json
```

where `GITHUB_RUN_ID` is only `github.run_id`.

GitHub keeps `run_id` stable when a workflow run is re-run and increments `github.run_attempt`. On a persistent/self-hosted runner, the next attempt can therefore see the same server-info path created by the previous attempt.

That can make old proxy metadata look current. If a previous background proxy process is still alive, the collision is even more misleading because a liveness check can succeed for a process that belongs to a different workflow attempt and may have been started with different credentials or endpoint configuration.

## Fix

Use a per-attempt key everywhere the action currently passes/derives the run-scoped server-info identity:

```text
${{ github.run_id }}-${{ github.run_attempt }}
```

The value is still passed through the existing `CODEX_RUN_ID` variable and `--github-run-id` helper option, so no TypeScript or generated bundle changes are required.

## Behaviour

- repeated action calls inside the **same** workflow attempt still share proxy state;
- a GitHub re-run gets a different server-info file because `run_attempt` increments;
- ordinary first-attempt paths become `<run_id>-1.json` instead of `<run_id>.json`.

## Regression coverage

Added a focused manifest test that verifies:

- both run-state call sites use `github.run_id` + `github.run_attempt`;
- no old run-id-only `CODEX_RUN_ID` assignment remains;
- the existing `$CODEX_HOME/$CODEX_RUN_ID.json` derivation is preserved.

## Validation

- branch is based directly on current upstream `main` (`c385816875cc2fc8e033ed9d1cba96f8c331210e`);
- branch is 0 commits behind upstream;
- production diff is exactly **2 additions / 2 deletions** in `action.yml`;
- no files under `src/` change, so `dist/main.js` remains valid.

## Risk

Low. The server-info format and proxy lifecycle are unchanged. The only change is the namespace used for per-run state, making it unique per GitHub re-run attempt while preserving reuse within an attempt.