### PR TITLE
fix: wait for the Codex platform binary before installing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -164,7 +164,25 @@ runs:
       shell: bash
       env:
         CODEX_VERSION: ${{ inputs['codex-version'] }}
-      run: npm install -g "@openai/codex@${CODEX_VERSION}"
+      run: |
+        set -euo pipefail
+        version="${CODEX_VERSION}"
+        if [ -z "${version}" ]; then
+          version="$(npm view @openai/codex version)"
+        fi
+        platform="$(node -p 'process.platform + "-" + process.arch')"
+        for _ in $(seq 1 30); do
+          if npm view "@openai/codex@${version}-${platform}" version >/dev/null 2>&1; then
+            break
+          fi
+          echo "Waiting for @openai/codex@${version}-${platform}; npm would skip that binary silently." >&2
+          sleep 10
+        done
+        npm install -g "@openai/codex@${version}"
+        if ! CODEX_HOME="${RUNNER_TEMP}/codex-install-check" codex --version >/dev/null 2>&1; then
+          echo "Codex CLI is installed but not runnable; its platform binary is missing." >&2
+          exit 1
+        fi
 
     - name: Install Codex Responses API proxy
       shell: bash


### PR DESCRIPTION
Closes #158.

## Why

`npm install -g "@openai/codex@${CODEX_VERSION}"` can exit `0` while leaving a CLI that cannot run. The platform binary is an aliased `optionalDependency`, so npm skips it silently when it is not published yet, and the job fails several steps later with `Missing optional dependency @openai/codex-linux-x64`.

Platform packages are published after the wrapper becomes `latest`, so there is a window where `latest` resolves but its binary does not exist. For `0.149.1` that was 115s on linux-x64 and 1413s on win32-x64. Measurements in #158.

Fixing the publish order itself belongs to `openai/codex`. This change stops the action from installing inside the window without noticing.

## What changed

Resolve the version first, wait for `@openai/codex@<version>-<platform>` to appear on the registry, then install, then confirm the CLI runs.

- The wait polls every 10s for up to 300s and breaks as soon as the package exists, so a normal run costs one extra `npm view`.
- 300s covers 60 of the 64 stable-release publish gaps I measured. Longer gaps now fail at the install step with a clear message instead of surfacing later as what looks like a Codex bug.
- The check runs with `CODEX_HOME` under `${RUNNER_TEMP}` so it does not create `~/.codex` before the action resolves the real Codex home.

## Testing

- `corepack pnpm test`
- `corepack pnpm run check`

`check` passes. `test` gives the same result before and after this change (138 pass, 1 fail, 2 cancelled); the failure is `--disable-sigusr1 is not allowed in NODE_OPTIONS` from a local Node 18 and is unrelated.

I also exercised the step against the registry: the normal path installs without waiting, a stubbed unpublished platform package makes it wait and then proceed once the package appears, and deleting `@openai/codex/node_modules/@openai/codex-<platform>` makes the final check fail as intended.
