### PR TITLE
fix: suppress workflow commands in Codex output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -365,7 +365,10 @@ runs:
         FORCE_COLOR: 1
       shell: bash
       run: |
-        exec env -u NODE_OPTIONS NODE_OPTIONS=--disable-sigusr1 node --disable-sigusr1 "$ACTION_PATH/dist/main.js" run-codex-exec \
+        workflow_command_token="codex-action-$(uuidgen)"
+        echo "::stop-commands::$workflow_command_token"
+        set +e
+        env -u NODE_OPTIONS NODE_OPTIONS=--disable-sigusr1 node --disable-sigusr1 "$ACTION_PATH/dist/main.js" run-codex-exec \
             --prompt "${CODEX_PROMPT}" \
             --prompt-file "${CODEX_PROMPT_FILE}" \
             --output-file "$CODEX_OUTPUT_FILE" \
@@ -380,3 +383,6 @@ runs:
             --effort "$CODEX_EFFORT" \
             --safety-strategy "$CODEX_SAFETY_STRATEGY" \
             --codex-user "$CODEX_USER"
+        run_codex_exit=$?
+        echo "::$workflow_command_token::"
+        exit "$run_codex_exit"

--- a/test/actionHardening.test.mjs
+++ b/test/actionHardening.test.mjs
@@ -190,13 +190,21 @@ setInterval(() => {}, 1000);
   }
 );
 
-test("Codex action and its descendants replace inherited Node options", () => {
+test("Codex output cannot be interpreted as GitHub workflow commands", () => {
   const step = actionStep("Run codex exec");
 
   assert.match(
     step,
-    /exec env -u NODE_OPTIONS NODE_OPTIONS=--disable-sigusr1 node --disable-sigusr1 "\$ACTION_PATH\/dist\/main\.js" run-codex-exec/
+    /workflow_command_token="codex-action-\$\(uuidgen\)"/
   );
+  assert.match(step, /echo "::stop-commands::\$workflow_command_token"/);
+  assert.match(step, /echo "::\$workflow_command_token::"/);
+  assert.match(
+    step,
+    /env -u NODE_OPTIONS NODE_OPTIONS=--disable-sigusr1 node --disable-sigusr1 "\$ACTION_PATH\/dist\/main\.js" run-codex-exec/
+  );
+  assert.match(step, /run_codex_exit=\$\?/);
+  assert.match(step, /exit "\$run_codex_exit"/);
 });
 
 test(


### PR DESCRIPTION
## Summary\n\nWrap the Codex execution step in GitHub Actions command suppression with a unique per-run token, then restore processing after the child exits. The action retains Codex's original exit code.\n\nThis prevents Codex tool and model output such as `##[add-matcher]` or `::warning::` from being executed by the GitHub runner as workflow commands.\n\nFixes #175.\n\n## Validation\n\n- `corepack pnpm run check`\n- `corepack pnpm run build`\n- `node --test --test-name-pattern='Codex output cannot be interpreted' test/actionHardening.test.mjs`\n- `git diff --check`\n\nThe complete test suite was started but its existing Linux process-isolation test does not complete in this sandbox.